### PR TITLE
Fix for missing vcgencmd error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG arch=arm
 ENV ARCH=$arch
 ENV NODE_ID=none
 
-# Required for GPU temperature to work
+# Required for GPU temperature scrape to work
 RUN apk add raspberrypi
 
 # Trick docker build in case qemu binary is not in dir.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ARG arch=arm
 ENV ARCH=$arch
 ENV NODE_ID=none
 
+# Required for GPU temperature to work
+RUN apk add raspberrypi
+
 # Trick docker build in case qemu binary is not in dir.
 COPY .blank tmp/qemu-$ARCH-static* /usr/bin/
 


### PR DESCRIPTION
Adding raspberrypi package for Alpine to fix the missing vcgencmd and enable GPU temperature scraping. The final image takes around 11.5MB after adding this package

Found the working solution on how to get it working on Alpine here: [link](https://dev.alpinelinux.org/~clandmeter/other/forum.alpinelinux.org/forum/kernel-and-hardware/raspberry-pi-get-temperatur.html)