### PR TITLE
Use native cross-compilation and add support for armv6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   global:
     - DOCKER_REPO=carlosedp/arm_exporter
     - GIMME_GO_VERSION=1.14.2
-    - ARCHS="linux/arm,linux/arm64"
+    - ARCHS="linux/arm/v6,linux/arm/v7,linux/arm64"
 
 before_install:
     - curl -fsSL https://get.docker.com | sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # Builder container
-FROM golang:1.14 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.14 AS builder
+# Install a go wrapper script converting Docker's $TARGETPLATFORM to $GOARCH
+# and $GOARM environment variables for cross-compiling.
+COPY --from=tonistiigi/xx:golang / /
+ARG TARGETPLATFORM
 
 WORKDIR $GOPATH
 


### PR DESCRIPTION
This leverages the pretty neat library:
https://github.com/tonistiigi/xx/tree/master/golang

Which installs this wrapper.sh
https://github.com/tonistiigi/xx/blob/master/golang/wrapper.sh

around the go binary, converting Docker's $TARGETPLATFORM like
linux/arm/v6 into Go's environment variables like GOARCH=arm GOARCH=v6.

Fixes #9

As a neat side-effect, the builds are much faster, not having to go through qemu any more.