### PR TITLE
Add support for armv6, for Raspberry Pi Zero

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,4 +63,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/arm,linux/arm64
+          platforms: linux/arm,linux/arm64,linux/arm/v6


### PR DESCRIPTION
Tested locally with:

```
$ docker buildx build --platform=linux/arm,linux/arm64,linux/arm/v6 .  --push --tag markhnsn/arm_exporter
```

Which seems to work, building for the arm6 environment: https://hub.docker.com/layers/markhnsn/arm_exporter/latest/images/sha256-deef7a9f2e61720844ce790389fb938b46e1dc878ebb57b7b792548c4de2566f?context=repo

And tested on my Raspberry Pi Zero + Raspberry Pi Zero WH

Fixes #13